### PR TITLE
Reduced the bundle.js size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,8 @@ module.exports = (env, argv) => {
                 }
             ]
         },
-        devtool: "inline-source-map",
+        // No map for production, reduces size of the bundle
+        devtool: argv.mode === "production" ? false : "source-map",
         plugins: [
             new CleanWebpackPlugin(dirName, {}),
             new MiniCssExtractPlugin({


### PR DESCRIPTION
Fixed a bug where bundle.js was too large. This was caused by an inline map being added to the file.

In production we don't create maps, in staging we make separate map files.

The expected bundle size is now less than 2.4mb